### PR TITLE
fix sustainability metric

### DIFF
--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -282,7 +282,7 @@ def apple_values_subtractive(
 
 
 def apple_values(method: str, board: Board, **kwargs) -> Union[float, int]:
-    """dispatch - defaults to 0 if method is none """
+    """dispatch - defaults to 0 if method is none"""
     if method is None or method == "None":
         return 0.0
     if method == "subtractive":

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -52,7 +52,7 @@ def sustainability_metric_deepmind(rewards: List[Dict[str, float]]):
     num_agents = len(rewards[0])
     total_rewards = [list(r.values()) for r in rewards]  # list of (list of rewards per agent) per episode
     nonzero_rewards = [num_agents - r.count(0) for r in total_rewards]  # how many agents had nonzero rewards per episode
-    episode_weighted_nonzero_rewards = [ep_num * nonzero_rewards[ep_num] for ep_num in range(len(total_rewards))]
+    episode_weighted_nonzero_rewards = [timestep * nonzero_rewards[timestep] for timestep in range(len(total_rewards))]
     return sum(episode_weighted_nonzero_rewards) / sum(nonzero_rewards)
 
 

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -52,6 +52,8 @@ def sustainability_metric_deepmind(rewards: List[Dict[str, float]]):
     num_agents = len(rewards[0])
     total_rewards = [list(r.values()) for r in rewards]  # list of (list of rewards per agent) per episode
     nonzero_rewards = [num_agents - r.count(0) for r in total_rewards]  # how many agents had nonzero rewards per episode
+    if sum(nonzero_rewards) == 0:
+        return len(total_rewards)
     episode_weighted_nonzero_rewards = [timestep * nonzero_rewards[timestep] for timestep in range(len(total_rewards))]
     return sum(episode_weighted_nonzero_rewards) / sum(nonzero_rewards)
 

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -50,11 +50,17 @@ def gini_coef(d: Dict[str, float]) -> float:
 # average timestep with nonzero agent reward
 def sustainability_metric_deepmind(rewards: List[Dict[str, float]]):
     num_agents = len(rewards[0])
-    total_rewards = [list(r.values()) for r in rewards]  # list of (list of rewards per agent) per episode
-    nonzero_rewards = [num_agents - r.count(0) for r in total_rewards]  # how many agents had nonzero rewards per episode
+    total_rewards = [
+        list(r.values()) for r in rewards
+    ]  # list of (list of rewards per agent) per episode
+    nonzero_rewards = [
+        num_agents - r.count(0) for r in total_rewards
+    ]  # how many agents had nonzero rewards per episode
     if sum(nonzero_rewards) == 0:
         return len(total_rewards)
-    episode_weighted_nonzero_rewards = [timestep * nonzero_rewards[timestep] for timestep in range(len(total_rewards))]
+    episode_weighted_nonzero_rewards = [
+        timestep * nonzero_rewards[timestep] for timestep in range(len(total_rewards))
+    ]
     return sum(episode_weighted_nonzero_rewards) / sum(nonzero_rewards)
 
 

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -47,11 +47,13 @@ def gini_coef(d: Dict[str, float]) -> float:
     return gini(list(d.values()))
 
 
-# fraction of agent-timesteps with nonzero reward
+# average timestep with nonzero agent reward
 def sustainability_metric_deepmind(rewards: List[Dict[str, float]]):
-    total_rewards = [list(r.values()) for r in rewards]
-    zero_rewards = sum([rewards.count(0) for rewards in total_rewards])
-    return (len(total_rewards) - zero_rewards) / len(total_rewards)
+    num_agents = len(rewards[0])
+    total_rewards = [list(r.values()) for r in rewards]  # list of (list of rewards per agent) per episode
+    nonzero_rewards = [num_agents - r.count(0) for r in total_rewards]  # how many agents had nonzero rewards per episode
+    episode_weighted_nonzero_rewards = [ep_num * nonzero_rewards[ep_num] for ep_num in range(len(total_rewards))]
+    return sum(episode_weighted_nonzero_rewards) / sum(nonzero_rewards)
 
 
 def sustainability_metric(method: str):

--- a/record_video_ray.py
+++ b/record_video_ray.py
@@ -111,7 +111,6 @@ class HarvestRecorder(HarvestEnv):
 if __name__ == "__main__":
 
     ray.init()
-
     register_env("CPRHarvestEnv-v0", lambda config: HarvestEnv(config, **env_config))
 
     trainer = ppo.PPOTrainer(
@@ -125,14 +124,3 @@ if __name__ == "__main__":
     recorder = HarvestRecorder(ray_config, trainer, checkpoint_no, **env_config)
 
     recorder.record()
-
-
-"""
-TODO
-
-- try `%run record_video_ray.py` with geneity="hom"
-    + debug `trainer.compute_action`
-- try training again with DQN
-- parse args for geneity, checkpoint_no
-- msg AK/QD
-"""


### PR DESCRIPTION
Old sustainability metric was calculating something like the fraction of agent-timesteps with nonzero reward. What we want is _S_: the average timestep number where an agent receives a nonzero reward. 

<img width="687" alt="Screen Shot 2021-05-09 at 19 46 15" src="https://user-images.githubusercontent.com/3505187/117590823-38bd2100-b0ff-11eb-9e3f-aa25825b9450.png">

Intuitively, if agents are gathering apples later and later into the episode, the environment is becoming more sustainable.