### PR TITLE
Compute all agent observations at once

### DIFF
--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -554,66 +554,70 @@ class HarvestGame:
             if other_name != agent_id and other_agent.pos.is_between(bound1, bound2)
         ]
 
-    def get_agent_obs(self, agent_id: str) -> Board:
-        agent = self.agents[agent_id]
-
+    def get_agents_obs(self) -> Dict[str, Board]:
+        # get full board
         apple_board = self.board
         agent_board = np.zeros_like(self.board)
         reputation_board = np.zeros_like(self.board)
-        for other_agent_id, other_agent in self.agents.items():
-            agent_board[other_agent.pos] = 1
-            reputation_board[other_agent.pos] = softmax_dict(
-                self.reputation, other_agent_id
+        for agent_id, agent in self.agents.items():
+            agent_board[agent.pos] = 1
+            reputation_board[agent.pos] = softmax_dict(
+                self.reputation, agent_id
             )
         wall_board = self.walls
 
-        # Add any extra layers before this line
-
+        # add any extra layers before this line
         full_board = np.stack(
             [apple_board, agent_board, wall_board, reputation_board], axis=-1
         )  # H x W x 4
-        rot = agent.rot
 
-        # Rotate the board so that the agent is always pointing up.
-        # I checked, the direction should be correct - still tests, will be good
-        board = np.rot90(full_board, rot)
+        # for each agent, get the appopriate slice
+        agents_obs = {}
+        for (agent_id, agent) in self.agents():
+            rot = agent.rot
 
-        max_i, max_j = board.shape[:2]
+            # Rotate the board so that the agent is always pointing up.
+            # I checked, the direction should be correct - still tests, will be good
+            board = np.rot90(full_board, rot)
 
-        if rot == 0:
-            agent_i, agent_j = agent.pos
-        elif rot == 1:
-            agent_i, agent_j = max_i - agent.pos[1] - 1, agent.pos[0]
-        elif rot == 2:
-            agent_i, agent_j = max_i - agent.pos[0] - 1, max_j - agent.pos[1] - 1
-        else:
-            agent_i, agent_j = agent.pos[1], max_j - agent.pos[0] - 1
+            max_i, max_j = board.shape[:2]
 
-        # Horizontal bounds
-        bounds_i = (agent_i - self.sight_dist + 1, agent_i + 1)
-        (bound_up, bound_down) = bounds_i
-        bounds_i_clipped = np.clip(bounds_i, 0, board.shape[0])
+            if rot == 0:
+                agent_i, agent_j = agent.pos
+            elif rot == 1:
+                agent_i, agent_j = max_i - agent.pos[1] - 1, agent.pos[0]
+            elif rot == 2:
+                agent_i, agent_j = max_i - agent.pos[0] - 1, max_j - agent.pos[1] - 1
+            else:
+                agent_i, agent_j = agent.pos[1], max_j - agent.pos[0] - 1
 
-        bounds_j = (agent_j - self.sight_width, agent_j + self.sight_width + 1)
-        (bound_left, bound_right) = bounds_j
-        bounds_j_clipped = np.clip(bounds_j, 0, board.shape[1])
+            # Horizontal bounds
+            bounds_i = (agent_i - self.sight_dist + 1, agent_i + 1)
+            (bound_up, bound_down) = bounds_i
+            bounds_i_clipped = np.clip(bounds_i, 0, board.shape[0])
 
-        base_slice = board[
-            slice(*bounds_i_clipped), slice(*bounds_j_clipped)
-        ]  # <= (H, W)
+            bounds_j = (agent_j - self.sight_width, agent_j + self.sight_width + 1)
+            (bound_left, bound_right) = bounds_j
+            bounds_j_clipped = np.clip(bounds_j, 0, board.shape[1])
 
-        if bound_up < 0:
-            padding = np.zeros((-bound_up, base_slice.shape[1], base_slice.shape[2]))
-            base_slice = np.concatenate([padding, base_slice], axis=0)
-        if bound_left < 0:
-            padding = np.zeros((base_slice.shape[0], -bound_left, base_slice.shape[2]))
-            base_slice = np.concatenate([padding, base_slice], axis=1)
-        if bound_right > max_j:  # board.shape[1]:
-            padding = np.zeros(
-                (base_slice.shape[0], bound_right - board.shape[1], base_slice.shape[2])
-            )
-            base_slice = np.concatenate([base_slice, padding], axis=1)
-        if bound_down > board.shape[0]:
-            raise ValueError("WTF")
+            base_slice = board[
+                slice(*bounds_i_clipped), slice(*bounds_j_clipped)
+            ]  # <= (H, W)
 
-        return base_slice  # H x W x 4
+            if bound_up < 0:
+                padding = np.zeros((-bound_up, base_slice.shape[1], base_slice.shape[2]))
+                base_slice = np.concatenate([padding, base_slice], axis=0)
+            if bound_left < 0:
+                padding = np.zeros((base_slice.shape[0], -bound_left, base_slice.shape[2]))
+                base_slice = np.concatenate([padding, base_slice], axis=1)
+            if bound_right > max_j:  # board.shape[1]:
+                padding = np.zeros(
+                    (base_slice.shape[0], bound_right - board.shape[1], base_slice.shape[2])
+                )
+                base_slice = np.concatenate([base_slice, padding], axis=1)
+            if bound_down > board.shape[0]:
+                raise ValueError("WTF")
+
+            agents_obs[agent_id] = base_slice  # H x W x 4
+
+        return agents_obs  

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -561,9 +561,7 @@ class HarvestGame:
         reputation_board = np.zeros_like(self.board)
         for agent_id, agent in self.agents.items():
             agent_board[agent.pos] = 1
-            reputation_board[agent.pos] = softmax_dict(
-                self.reputation, agent_id
-            )
+            reputation_board[agent.pos] = softmax_dict(self.reputation, agent_id)
         wall_board = self.walls
 
         # add any extra layers before this line
@@ -573,7 +571,7 @@ class HarvestGame:
 
         # for each agent, get the appopriate slice
         agents_obs = {}
-        for (agent_id, agent) in self.agents():
+        for (agent_id, agent) in self.agents.items():
             rot = agent.rot
 
             # Rotate the board so that the agent is always pointing up.
@@ -605,14 +603,22 @@ class HarvestGame:
             ]  # <= (H, W)
 
             if bound_up < 0:
-                padding = np.zeros((-bound_up, base_slice.shape[1], base_slice.shape[2]))
+                padding = np.zeros(
+                    (-bound_up, base_slice.shape[1], base_slice.shape[2])
+                )
                 base_slice = np.concatenate([padding, base_slice], axis=0)
             if bound_left < 0:
-                padding = np.zeros((base_slice.shape[0], -bound_left, base_slice.shape[2]))
+                padding = np.zeros(
+                    (base_slice.shape[0], -bound_left, base_slice.shape[2])
+                )
                 base_slice = np.concatenate([padding, base_slice], axis=1)
             if bound_right > max_j:  # board.shape[1]:
                 padding = np.zeros(
-                    (base_slice.shape[0], bound_right - board.shape[1], base_slice.shape[2])
+                    (
+                        base_slice.shape[0],
+                        bound_right - board.shape[1],
+                        base_slice.shape[2],
+                    )
                 )
                 base_slice = np.concatenate([base_slice, padding], axis=1)
             if bound_down > board.shape[0]:
@@ -620,4 +626,4 @@ class HarvestGame:
 
             agents_obs[agent_id] = base_slice  # H x W x 4
 
-        return agents_obs  
+        return agents_obs

--- a/cpr_reputation/environments.py
+++ b/cpr_reputation/environments.py
@@ -27,20 +27,12 @@ class HarvestEnv(RayMultiAgentEnv):
     def reset(self) -> Dict[str, np.ndarray]:
         self.game.reset()
         self.original_board = np.copy(self.game.board)
-        return {
-            agent_id: self.game.get_agent_obs(agent_id)
-            for agent_id, _ in self.game.agents.items()
-        }
+        return self.game.get_agents_obs()
 
     def step(self, actions: Dict[str, int]):
-
         rewards = self.game.step(actions)
 
-        # get observations, done, info
-        obs = {
-            agent_id: self.game.get_agent_obs(agent_id)
-            for agent_id, _ in self.game.agents.items()
-        }
+        obs = self.game.get_agents_obs()
 
         isdone = self.game.time > 1000 or self.game.board.sum() == 0
         done = {agent_id: isdone for agent_id, _ in self.game.agents.items()}

--- a/cpr_reputation/environments.py
+++ b/cpr_reputation/environments.py
@@ -123,7 +123,7 @@ class SingleHarvestEnv(gym.Env):
         self.last_actions = {}
 
         obs = {
-            agent_id: self.game.get_agent_obs(agent_id)
+            agent_id: self.game.get_agents_obs()[agent_id]
             for agent_id, _ in self.game.agents.items()
         }
 
@@ -138,7 +138,7 @@ class SingleHarvestEnv(gym.Env):
 
         # get observations, done, info
         obs = {
-            agent_id: self.game.get_agent_obs(agent_id)
+            agent_id: self.game.get_agents_obs()[agent_id]
             for agent_id, _ in self.game.agents.items()
         }
 

--- a/cpr_reputation/recording.py
+++ b/cpr_reputation/recording.py
@@ -49,13 +49,13 @@ class HarvestRecorder(HarvestEnv):
             if self.heterogeneous:
                 for agent_id, _ in self.game.agents.items():
                     actions[agent_id] = self.trainer.compute_action(
-                        observation=self.game.get_agent_obs(agent_id),
+                        observation=self.game.get_agent_obs()[agent_id],
                         policy_id=agent_id,
                     )
             else:
                 for agent_id, _ in self.game.agents.items():
                     actions[agent_id] = self.trainer.compute_action(
-                        observation=self.game.get_agent_obs(agent_id),
+                        observation=self.game.get_agents_obs()[agent_id],
                         policy_id="walker",
                     )
 

--- a/cpr_reputation/recording.py
+++ b/cpr_reputation/recording.py
@@ -49,7 +49,7 @@ class HarvestRecorder(HarvestEnv):
             if self.heterogeneous:
                 for agent_id, _ in self.game.agents.items():
                     actions[agent_id] = self.trainer.compute_action(
-                        observation=self.game.get_agent_obs()[agent_id],
+                        observation=self.game.get_agents_obs()[agent_id],
                         policy_id=agent_id,
                     )
             else:

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -80,7 +80,7 @@ def retrieve_checkpoint(
 
 def softmax_dict(reputation: Dict[str, float], agent_id: str) -> float:
     reputations = np.array(list(reputation.values()))
-    return reputation[agent_id] / np.exp(reputations).sum()
+    return np.exp(reputation[agent_id]) / np.exp(reputations).sum()
 
 
 # def get_config(

--- a/record_video_ray.py
+++ b/record_video_ray.py
@@ -55,13 +55,13 @@ class HarvestRecorder(HarvestEnv):
             if self.heterogeneous:
                 for agent_id, _ in self.game.agents.items():
                     actions[agent_id] = self.trainer.compute_action(
-                        observation=self.game.get_agent_obs(agent_id),
+                        observation=self.game.get_agents_obs()[agent_id],
                         policy_id=agent_id,
                     )
             else:
                 for agent_id, _ in self.game.agents.items():
                     actions[agent_id] = self.trainer.compute_action(
-                        observation=self.game.get_agent_obs(agent_id),
+                        observation=self.game.get_agents_obs()[agent_id],
                         policy_id="walker",
                     )
 

--- a/test/property/test_board.py
+++ b/test/property/test_board.py
@@ -11,7 +11,7 @@ from hypothesis.strategies import integers
     sight_width=integers(min_value=2, max_value=50),
     sight_dist=integers(min_value=3, max_value=100),
 )
-def test_get_agent_obs_board_shape(
+def test_get_agents_obs_board_shape(
     num_agents: int, size_i: int, size_j: int, sight_width: int, sight_dist: int
 ):
     env1 = HarvestGame(
@@ -24,17 +24,17 @@ def test_get_agent_obs_board_shape(
     constant_obs_shape = (sight_dist, 2 * sight_width + 1, 4)
     env1.agents[ag0].rot = 0  # facing north
     assert (
-        env1.get_agent_obs(ag0).shape == constant_obs_shape
+        env1.get_agents_obs()[ag0].shape == constant_obs_shape
     ), "north facing window doesn't work"
     env1.agents[ag0].rot = 1  # facing east
     assert (
-        env1.get_agent_obs(ag0).shape == constant_obs_shape
+        env1.get_agents_obs()[ag0].shape == constant_obs_shape
     ), "east facing window doesn't work"
     env1.agents[ag0].rot = 2  # facing south
     assert (
-        env1.get_agent_obs(ag0).shape == constant_obs_shape
+        env1.get_agents_obs()[ag0].shape == constant_obs_shape
     ), "south facing window doesn't work"
     env1.agents[ag0].rot = 3  # facing west
     assert (
-        env1.get_agent_obs(ag0).shape == constant_obs_shape
+        env1.get_agents_obs()[ag0].shape == constant_obs_shape
     ), "west facing window doesn't work"

--- a/test/unit/test_board.py
+++ b/test/unit/test_board.py
@@ -114,23 +114,23 @@ def test_get_neighbors_radius_2():
         assert pos in neighbors
 
 
-def test_get_agent_obs_board_shape():
+def test_get_agents_obs_board_shape():
     env = HarvestGame(
         size=Position(100, 100), num_agents=1, sight_dist=20, sight_width=10
     )
     env.agents["Agent0"].rot = 0  # facing north
-    assert env.get_agent_obs("Agent0").shape == (20, 21, 4)
+    assert env.get_agents_obs()["Agent0"].shape == (20, 21, 4)
     env.agents["Agent0"].rot = 1  # facing east
-    assert env.get_agent_obs("Agent0").shape == (20, 21, 4)
+    assert env.get_agents_obs()["Agent0"].shape == (20, 21, 4)
     env.agents["Agent0"].rot = 2  # facing south
-    assert env.get_agent_obs("Agent0").shape == (20, 21, 4)
+    assert env.get_agents_obs()["Agent0"].shape == (20, 21, 4)
     env.agents["Agent0"].rot = 3  # facing west
-    assert env.get_agent_obs("Agent0").shape == (20, 21, 4)
+    assert env.get_agents_obs()["Agent0"].shape == (20, 21, 4)
 
 
-def test_get_agent_obs_board_items(example_env1):
+def test_get_agents_obs_board_items(example_env1):
     env = example_env1
-    obs = env.get_agent_obs("Agent3")  # facing south
+    obs = env.get_agents_obs()["Agent3"]  # facing south
     obs_apples = np.where(obs[:, :, 0])
     obs_agents = np.where(obs[:, :, 1])
     obs_walls = np.where(obs[:, :, 2])
@@ -158,7 +158,7 @@ def test_get_agent_obs_board_items(example_env1):
     assert sorted(zip(*obs_walls)) == sorted(expected_walls)
 
     env._rotate_agent("Agent3", -1)  # facing east
-    obs = env.get_agent_obs("Agent3")
+    obs = env.get_agents_obs()["Agent3"]
     obs_apples = np.where(obs[:, :, 0])
     obs_agents = np.where(obs[:, :, 1])
     obs_walls = np.where(obs[:, :, 2])
@@ -197,7 +197,7 @@ def test_get_agent_obs_board_items(example_env1):
     # assert sorted(zip(*obs_walls)) == sorted(expected_walls)
 
     env._rotate_agent("Agent3", -1)  # facing north
-    obs = env.get_agent_obs("Agent3")
+    obs = env.get_agents_obs()["Agent3"]
     obs_apples = np.where(obs[:, :, 0])
     obs_agents = np.where(obs[:, :, 1])
     obs_walls = np.where(obs[:, :, 2])
@@ -220,7 +220,7 @@ def test_get_agent_obs_board_items(example_env1):
     # assert sorted(zip(*obs_walls)) == sorted(expected_walls)
 
     env._rotate_agent("Agent3", -1)  # facing west
-    obs = env.get_agent_obs("Agent3")
+    obs = env.get_agents_obs()["Agent3"]
     obs_apples = np.where(obs[:, :, 0])
     obs_agents = np.where(obs[:, :, 1])
     obs_walls = np.where(obs[:, :, 2])


### PR DESCRIPTION
Per Ariel's comments about `get_agent_obs` being a major bottleneck, this PR (hopefully) speeds up the calculation of agent observations by reusing the board (rather than re-initializing it) for each agent.

I recently started using a new laptop, so I haven't been able to verify whether or not this version runs any faster.