### PR TITLE
Replace softmax with identity

### DIFF
--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -561,7 +561,9 @@ class HarvestGame:
         reputation_board = np.zeros_like(self.board)
         for agent_id, agent in self.agents.items():
             agent_board[agent.pos] = 1
-            reputation_board[agent.pos] = softmax_dict(self.reputation, agent_id)
+            reputation_board[agent.pos] = self.reputation[
+                agent_id
+            ]  # softmax_dict(self.reputation, agent_id)
         wall_board = self.walls
 
         # add any extra layers before this line

--- a/rendering_test.py
+++ b/rendering_test.py
@@ -28,8 +28,7 @@ parser.add_argument("--stop-reward", type=float, default=9.0)
 
 
 class CustomRenderedEnv(gym.Env, MultiAgentEnv):
-    """Example of a custom env, for which you can specify rendering behavior.
-    """
+    """Example of a custom env, for which you can specify rendering behavior."""
 
     metadata = {
         "render.modes": ["rgb_array"],


### PR DESCRIPTION
Instead of computing the softmax of reputation, just feed in the plain reputation values.

After this, we can find a normalization strategy that makes sense.