### PR TITLE
new config without tagging values metric

### DIFF
--- a/configs/apple_values_rep.yaml
+++ b/configs/apple_values_rep.yaml
@@ -6,7 +6,7 @@ env_config:
   sight_dist: 10
   num_crosses: 45
   ceasefire: 0
-  apple_values_method: subtractive
+  apple_values_method: inverse
   tagging_values_method: 
   sustainability_metric: deepmind
 ray_config:

--- a/configs/apple_values_rep.yaml
+++ b/configs/apple_values_rep.yaml
@@ -1,0 +1,26 @@
+---
+env_config:
+  num_agents: 10
+  size: !!python/tuple [22, 42]
+  sight_width: 5
+  sight_dist: 10
+  num_crosses: 45
+  ceasefire: 0
+  apple_values_method: subtractive
+  tagging_values_method: 
+  sustainability_metric: deepmind
+ray_config:
+  framework: torch
+  train_batch_size: 4000
+  rollout_fragment_length: 1000
+  sgd_minibatch_size: 512
+  num_sgd_iter: 3
+  lambda: 0.92
+  kl_coeff: 0.2
+  lr: 1.0e-5
+  vf_loss_coeff: 1.0e-2
+  gamma: 0.99
+run_config:
+  heterogeneous: true
+  verbose: true
+  wandb_key_file: WANDB_TOKEN

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -274,12 +274,13 @@ def apple_values_ternary(board: Board, position: Position) -> int:
 
 
 def apple_values_subtractive(
-    board: Board, position: Position, factor: float = 1.0
+    board: Board, position: Position
 ) -> float:
     """reputational magnitude of taking an apple is inversely proportional to the number of apples around it"""
     kernel = NEIGHBOR_KERNEL
+    num_neighbors = kernel.sum()
     neighbor_apple_sums = convolve(board, kernel, mode="constant")
-    return (kernel.sum() - neighbor_apple_sums[tuple(position)]) / factor
+    return (num_neighbors - neighbor_apple_sums[tuple(position)]) / num_neighbors
 
 
 def apple_values(method: str, board: Board, **kwargs) -> Union[float, int]:
@@ -506,8 +507,8 @@ class HarvestGame:
                 self.apple_values_method,
                 self.board,
                 position=current_pos,
-                factor=NEIGHBOR_KERNEL.sum(),
             )
+            self.reputation[agent_id] = np.clip(self.reputation[agent_id], -1000, 1000)
             return 1.0
         else:  # no apple in new cell
             return 0.0

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -179,10 +179,10 @@ def random_board(size: Tuple[int, int], prob: float = 0.1) -> Board:
     return (prob_map < prob).astype(np.int8)
 
 
-def random_crosses(size: Position, num_crosses: int = 10) -> Board:
+def random_crosses(size: Position, num_crosses: int = 10, seed=1) -> Board:
     """Creates a board with random cross-shaped apple patterns"""
     all_positions = [(row, col) for col in range(size[1]) for row in range(size[0])]
-    random_idx = np.random.choice(range(len(all_positions)), num_crosses, replace=False)
+    random_idx = np.random.choice(range(len(all_positions)), num_crosses, replace=False, seed=seed)
     initial_apples = [all_positions[i] for i in random_idx]
     board = create_board(size, initial_apples)
     return board

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -283,6 +283,15 @@ def apple_values_subtractive(
     return (num_neighbors - neighbor_apple_sums[tuple(position)]) / num_neighbors
 
 
+def apple_values_inverse(
+    board: Board, position: Position
+) -> float:
+    kernel = NEIGHBOR_KERNEL
+    neighbor_apple_sums = convolve(board, kernel, mode="constant")
+    return 1 / (1 + neighbor_apple_sums)
+
+
+
 def apple_values(method: str, board: Board, **kwargs) -> Union[float, int]:
     """dispatch - defaults to 0 if method is none"""
     if method is None or method == "None":
@@ -291,6 +300,8 @@ def apple_values(method: str, board: Board, **kwargs) -> Union[float, int]:
         return apple_values_subtractive(board, **kwargs)
     if method == "ternary":
         return apple_values_ternary(board, **kwargs)
+    if method == "inverse":
+        return apple_values_inverse(board, **kwargs)
     raise ValueError(f"Improper apple value argument {method}")
 
 

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -562,9 +562,7 @@ class HarvestGame:
         reputation_board = np.zeros_like(self.board)
         for agent_id, agent in self.agents.items():
             agent_board[agent.pos] = 1
-            reputation_board[agent.pos] = self.reputation[
-                agent_id
-            ]  # softmax_dict(self.reputation, agent_id)
+            reputation_board[agent.pos] = softmax_dict(self.reputation, agent_id)
         wall_board = self.walls
 
         # add any extra layers before this line

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -273,9 +273,7 @@ def apple_values_ternary(board: Board, position: Position) -> int:
     return cache[position]
 
 
-def apple_values_subtractive(
-    board: Board, position: Position
-) -> float:
+def apple_values_subtractive(board: Board, position: Position) -> float:
     """reputational magnitude of taking an apple is inversely proportional to the number of apples around it"""
     kernel = NEIGHBOR_KERNEL
     num_neighbors = kernel.sum()
@@ -283,13 +281,10 @@ def apple_values_subtractive(
     return (num_neighbors - neighbor_apple_sums[tuple(position)]) / num_neighbors
 
 
-def apple_values_inverse(
-    board: Board, position: Position
-) -> float:
+def apple_values_inverse(board: Board, position: Position) -> float:
     kernel = NEIGHBOR_KERNEL
     neighbor_apple_sums = convolve(board, kernel, mode="constant")
-    return 1 / (1 + neighbor_apple_sums)
-
+    return 1 / (1 + neighbor_apple_sums[tuple(position)])
 
 
 def apple_values(method: str, board: Board, **kwargs) -> Union[float, int]:

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -179,10 +179,11 @@ def random_board(size: Tuple[int, int], prob: float = 0.1) -> Board:
     return (prob_map < prob).astype(np.int8)
 
 
-def random_crosses(size: Position, num_crosses: int = 10, seed=1) -> Board:
+def random_crosses(size: Position, num_crosses: int = 10, seed: int = 1) -> Board:
     """Creates a board with random cross-shaped apple patterns"""
     all_positions = [(row, col) for col in range(size[1]) for row in range(size[0])]
-    random_idx = np.random.choice(range(len(all_positions)), num_crosses, replace=False, seed=seed)
+    np.random.seed(seed)
+    random_idx = np.random.choice(range(len(all_positions)), num_crosses, replace=False)
     initial_apples = [all_positions[i] for i in random_idx]
     board = create_board(size, initial_apples)
     return board

--- a/cpr_reputation/board.py
+++ b/cpr_reputation/board.py
@@ -568,7 +568,7 @@ class HarvestGame:
         reputation_board = np.zeros_like(self.board)
         for agent_id, agent in self.agents.items():
             agent_board[agent.pos] = 1
-            reputation_board[agent.pos] = softmax_dict(self.reputation, agent_id)
+            reputation_board[agent.pos] = self.reputation[agent_id] / 1000
         wall_board = self.walls
 
         # add any extra layers before this line

--- a/cpr_reputation/environments.py
+++ b/cpr_reputation/environments.py
@@ -23,7 +23,7 @@ class HarvestEnv(RayMultiAgentEnv, gym.Env):
         self.game = HarvestGame(**env_config)
 
         self.observation_space = Box(
-            0, 1, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
+            -1.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
         )
 
         self.action_space = Discrete(8)
@@ -108,7 +108,7 @@ class SingleHarvestEnv(gym.Env):
         self.agent_id = list(self.game.agents.keys())[0]
 
         self.observation_space = Box(
-            0, 1, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
+            -1.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
         )
 
         self.action_space = Discrete(8)

--- a/cpr_reputation/environments.py
+++ b/cpr_reputation/environments.py
@@ -23,7 +23,7 @@ class HarvestEnv(RayMultiAgentEnv, gym.Env):
         self.game = HarvestGame(**env_config)
 
         self.observation_space = Box(
-            -1.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
+            0.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
         )
 
         self.action_space = Discrete(8)
@@ -108,7 +108,7 @@ class SingleHarvestEnv(gym.Env):
         self.agent_id = list(self.game.agents.keys())[0]
 
         self.observation_space = Box(
-            -1.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
+            0.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
         )
 
         self.action_space = Discrete(8)

--- a/cpr_reputation/environments.py
+++ b/cpr_reputation/environments.py
@@ -23,7 +23,10 @@ class HarvestEnv(RayMultiAgentEnv, gym.Env):
         self.game = HarvestGame(**env_config)
 
         self.observation_space = Box(
-            0.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
+            0.0,
+            1.0,
+            (self.game.sight_dist, 2 * self.game.sight_width + 1, 4),
+            np.float32,
         )
 
         self.action_space = Discrete(8)
@@ -108,7 +111,10 @@ class SingleHarvestEnv(gym.Env):
         self.agent_id = list(self.game.agents.keys())[0]
 
         self.observation_space = Box(
-            0.0, 1.0, (self.game.sight_dist, 2 * self.game.sight_width + 1, 4), np.float32,
+            0.0,
+            1.0,
+            (self.game.sight_dist, 2 * self.game.sight_width + 1, 4),
+            np.float32,
         )
 
         self.action_space = Discrete(8)

--- a/cpr_reputation/environments.py
+++ b/cpr_reputation/environments.py
@@ -23,7 +23,7 @@ class HarvestEnv(RayMultiAgentEnv, gym.Env):
         self.game = HarvestGame(**env_config)
 
         self.observation_space = Box(
-            0.0,
+            -1.0,
             1.0,
             (self.game.sight_dist, 2 * self.game.sight_width + 1, 4),
             np.float32,
@@ -111,7 +111,7 @@ class SingleHarvestEnv(gym.Env):
         self.agent_id = list(self.game.agents.keys())[0]
 
         self.observation_space = Box(
-            0.0,
+            -1.0,
             1.0,
             (self.game.sight_dist, 2 * self.game.sight_width + 1, 4),
             np.float32,

--- a/cpr_reputation/metrics.py
+++ b/cpr_reputation/metrics.py
@@ -64,7 +64,6 @@ class CPRCallbacks(DefaultCallbacks):
         episode.user_data["rewards_dict"] = defaultdict(float)
         episode.user_data["rewards_gini"] = list()
         episode.user_data["reputations"] = list()
-        episode.user_data["reputations_gini"] = list()
         episode.user_data["num_shots"] = list()
         episode.user_data["sustainability"] = list()
         episode.user_data["peace"] = list()
@@ -91,7 +90,6 @@ class CPRCallbacks(DefaultCallbacks):
             gini_coef(episode.user_data["rewards_dict"])
         )
         episode.user_data["reputations"].append(reputations)
-        episode.user_data["reputations_gini"].append(gini_coef(reputations))
         episode.user_data["num_shots"].append(num_shots)
         sus_metric = sustainability_metric(
             base_env.get_unwrapped()[0].game.sustainability_metric
@@ -140,9 +138,6 @@ class CPRCallbacks(DefaultCallbacks):
             )
             / episode.length
         )
-        episode.custom_metrics["reputations_gini"] = episode.user_data[
-            "reputations_gini"
-        ][-1]
         episode.custom_metrics["num_shots"] = sum(
             [
                 sum(list(num_shots.values()))

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -79,7 +79,7 @@ def retrieve_checkpoint(
 
 
 def softmax_dict(reputation: Dict[str, float], agent_id: str) -> float:
-    reputations = np.array(list(reputation.values()))
+    reputations = np.array(list(reputation.values())) / 1000
     return np.exp(reputation[agent_id]) / np.exp(reputations).sum()
 
 

--- a/cpr_reputation/utils.py
+++ b/cpr_reputation/utils.py
@@ -80,7 +80,7 @@ def retrieve_checkpoint(
 
 def softmax_dict(reputation: Dict[str, float], agent_id: str) -> float:
     reputations = np.array(list(reputation.values())) / 1000
-    return np.exp(reputation[agent_id]) / np.exp(reputations).sum()
+    return np.exp(reputation[agent_id] / 1000) / np.exp(reputations).sum()
 
 
 # def get_config(

--- a/learn.py
+++ b/learn.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     walker_policy = (
         None,
         Box(
-            -1.0,
+            0.0,
             1.0,
             (env_config["sight_dist"], 2 * env_config["sight_width"] + 1, 4),
             np.float32,

--- a/learn.py
+++ b/learn.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     walker_policy = (
         None,
         Box(
-            0.0,
+            -1.0,
             1.0,
             (env_config["sight_dist"], 2 * env_config["sight_width"] + 1, 4),
             np.float32,

--- a/learn.py
+++ b/learn.py
@@ -69,7 +69,7 @@ if __name__ == "__main__":
         monitor_gym=True,
         entity="marl-cpr",
         sync_tensorboard=True,
-        config=config
+        config=config,
     )
 
     register_env("CPRHarvestEnv-v0", lambda config: HarvestEnv(env_config))

--- a/learning_ray_tune.py
+++ b/learning_ray_tune.py
@@ -45,7 +45,7 @@ defaults_ini = {
 walker1 = (
     None,
     Box(
-        -1.0,
+        0.0,
         1.0,
         (defaults_ini["sight_dist"], 2 * defaults_ini["sight_width"] + 1, 3),
         np.float32,

--- a/learning_ray_tune.py
+++ b/learning_ray_tune.py
@@ -45,7 +45,7 @@ defaults_ini = {
 walker1 = (
     None,
     Box(
-        0.0,
+        -1.0,
         1.0,
         (defaults_ini["sight_dist"], 2 * defaults_ini["sight_width"] + 1, 3),
         np.float32,

--- a/record_video_ray.py
+++ b/record_video_ray.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     walker_policy = (
         None,
         Box(
-            -1.0,
+            0.0,
             1.0,
             (env_config["sight_dist"], 2 * env_config["sight_width"] + 1, 4),
             np.float32,

--- a/record_video_ray.py
+++ b/record_video_ray.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     walker_policy = (
         None,
         Box(
-            0.0,
+            -1.0,
             1.0,
             (env_config["sight_dist"], 2 * env_config["sight_width"] + 1, 4),
             np.float32,

--- a/test/unit/test_board.py
+++ b/test/unit/test_board.py
@@ -364,10 +364,10 @@ def test_apple_values_subtractive():
     np.random.seed(0)
     env1 = HarvestGame(num_agents=2, size=Position(10, 10))
     assert (
-        apple_values("subtractive", env1.board, position=Position(7, 3), factor=1)
+        apple_values("subtractive", env1.board, position=Position(7, 3))
         == 8.0
     )
     assert (
-        apple_values("subtractive", env1.board, position=Position(1, 0), factor=1)
+        apple_values("subtractive", env1.board, position=Position(1, 0))
         == 11.0
     )

--- a/test/unit/test_board.py
+++ b/test/unit/test_board.py
@@ -361,7 +361,7 @@ def test_regenerate_apples_with_step():
 
 
 def test_apple_values_subtractive():
-    np.random.seed(0)
+    np.random.seed(1)
     env1 = HarvestGame(num_agents=2, size=Position(10, 10))
-    assert apple_values("subtractive", env1.board, position=Position(7, 3)) == 8 / 12
-    assert apple_values("subtractive", env1.board, position=Position(1, 0)) == 11 / 12
+    assert apple_values("subtractive", env1.board, position=Position(7, 3)) == 6 / 12
+    assert apple_values("subtractive", env1.board, position=Position(3, 7)) == 4 / 12

--- a/test/unit/test_board.py
+++ b/test/unit/test_board.py
@@ -363,11 +363,5 @@ def test_regenerate_apples_with_step():
 def test_apple_values_subtractive():
     np.random.seed(0)
     env1 = HarvestGame(num_agents=2, size=Position(10, 10))
-    assert (
-        apple_values("subtractive", env1.board, position=Position(7, 3))
-        == 8/12
-    )
-    assert (
-        apple_values("subtractive", env1.board, position=Position(1, 0))
-        == 11/12
-    )
+    assert apple_values("subtractive", env1.board, position=Position(7, 3)) == 8 / 12
+    assert apple_values("subtractive", env1.board, position=Position(1, 0)) == 11 / 12

--- a/test/unit/test_board.py
+++ b/test/unit/test_board.py
@@ -365,9 +365,9 @@ def test_apple_values_subtractive():
     env1 = HarvestGame(num_agents=2, size=Position(10, 10))
     assert (
         apple_values("subtractive", env1.board, position=Position(7, 3))
-        == 8.0
+        == 8/12
     )
     assert (
         apple_values("subtractive", env1.board, position=Position(1, 0))
-        == 11.0
+        == 11/12
     )


### PR DESCRIPTION
Addresses #64 and #68.

- Creates a new config: `apple_values_rep`, which specifies only an `apple_values_method` (and not a `tagging_values_method`)
- Clips reputation to within [-1000, 1000], and normalizes the reputation value which gets fed into the agents' observations: `softmax(reputation / 1000)`
- Adds a new `apple_values_method` called `apple_values_inverse`, which weights each apple by `1 / (num_neighbors + 1)`. This should punish agents taking "critical apples" more severely than the `apple_values_subtractive` method.
- Removes the `reputations_gini` metric

A few notes:

- We have discussed changing the custom reputation score for a few behaviors: 1. taking an apple (bad), 2. being near an apple but not taking it (good), 3. tagging an agent (good or bad, depending on the reputation of that agent). We agreed on Friday that (3) is problematic, so I took it out in this PR. The only way reputation changes now is (1) -- I would like to see how agents behave with this simple reputation scheme before we modify it any further.
- We also discussed whether scaling reputation values by a constant multiplier would affect the softmax values. To see that it does: consider the output of the softmax function for `(r_1, r_2) = (1, 2)` vs. `(r_1, r_2) = (1000, 2000)`. In the first case, the values are `e/(e + e^2)` and `e^2/(e + e^2)`; in the second, they are `e^1000/(e^1000 + e^2000)` and `e^2000/(e^1000 + e^2000)`. The former values are closer together than the latter values (which are essentially 0 and 1).
- Since the softmax function has the range [0, 1], we can keep the Box bounds as they are for now.